### PR TITLE
    [GH-36] fixed: path to npm cache for itchio workflow

### DIFF
--- a/.github/workflows/itchio-deploy.yaml
+++ b/.github/workflows/itchio-deploy.yaml
@@ -24,6 +24,7 @@ jobs:
         with:
           node-version: "16.x"
           cache: 'npm'
+          cache-dependency-path: tic-tac-toe-project/yarn.lock
         env:
           CI: true
 


### PR DESCRIPTION
    GitHub Issue: https://github.com/devshareacademy/project-roadmap/issues/36